### PR TITLE
We will not be forced to env and add symfony dump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,21 @@
         "classmap": [
             "core/",
             "app/"
+        ],
+        "files": ["core/utils/helpers.php"]
+    },
+    "autoload-dev": {
+        "files": [
+            "app/bootstrap.php",
+            "core/bootstrap.php"
         ]
     },
     "minimum-stability": "dev",
     "require-dev": {
-        "vlucas/phpdotenv": "5.4.x-dev"
+        "vlucas/phpdotenv": "5.4.x-dev",
+        "symfony/var-dumper": "6.1.x-dev"
+    },
+    "scripts": {
+        "test": "phpunit tests --colors"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18da68161a67a662cdd9597df362e7ef",
+    "content-hash": "41cecf4815890145bcfe62d917df7d34",
     "packages": [],
     "packages-dev": [
         {
@@ -391,6 +391,94 @@
             "time": "2021-09-13T13:58:33+00:00"
         },
         {
+            "name": "symfony/var-dumper",
+            "version": "6.1.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "89d8bba08e70ef0f57ba589309fd2df9df2a606c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89d8bba08e70ef0f57ba589309fd2df9df2a606c",
+                "reference": "89d8bba08e70ef0f57ba589309fd2df9df2a606c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<5.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-17T16:30:50+00:00"
+        },
+        {
             "name": "vlucas/phpdotenv",
             "version": "dev-master",
             "source": {
@@ -475,7 +563,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "vlucas/phpdotenv": 20
+        "vlucas/phpdotenv": 20,
+        "symfony/var-dumper": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/core/Kernel.php
+++ b/core/Kernel.php
@@ -29,8 +29,9 @@ class Kernel implements IKernel
     public static function Start()
     {
         $App = new static;
-
-        Dotenv::createImmutable($_ENV['ROOT_PROJECT'])->load();
+        if (file_exists($_ENV['ROOT_PROJECT'] . '/.env')) {
+            Dotenv::createImmutable($_ENV['ROOT_PROJECT'])->load();
+        }
 
         array_filter($App->option['ENV'], function ($value, $key) {
             $_ENV[$key] = $value;

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -2,5 +2,3 @@
 
 $_ENV['ROOT_FRAMEWORK'] = __DIR__;
 
-require('utils/debug.php');
-require('utils/view.php');

--- a/core/database/DB.php
+++ b/core/database/DB.php
@@ -17,9 +17,10 @@ class DB implements IDB
     {
         try {
             $this->connect = new PDO(
-                "{$_ENV['DB_CONNECTION']}:host={$_ENV['DB_HOST']};dbname={$_ENV['DB_DATABASE']}",
-                $_ENV['DB_USERNAME'],
-                $_ENV['DB_PASSWORD']
+                env('DB_CONNECTION', 'mysql') . ":host=" . env('DB_HOST', 'localhost') .
+                ";dbname=" . env('DB_DATABASE', 'unknownrori'),
+                env('DB_USERNAME', 'root'),
+                env('DB_PASSWORD')
             );
             $this->connect->setAttribute(PDO::ATTR_ERRMODE, require("{$_ENV['APP_DIR']}/config/db.php"));
         } catch (Exception $e) {

--- a/core/utils/debug.php
+++ b/core/utils/debug.php
@@ -3,33 +3,33 @@
 /**
  * Your typical Die and Dump in Laravel, but different
  */
-function dd(...$arguments)
-{
-    echo "<style>
-        pre.dump {
-            background-color: #18171B;
-            color: white;
-            line-height: 1.2em;
-            font: 12px Menlo, Monaco, Consolas, monospace;
-            word-wrap: break-word;
-            white-space: pre-wrap;
-            position: relative;
-            z-index: 99999;
-            word-break: break-all;
-        }
-        pre.dump:after {
-            content: '';
-            visibility: hidden;
-            display: block;
-            height: 0;
-            clear: both;
-        }
-    </style>";
-    echo '<pre class="dump">';
-    var_dump(...$arguments);
-    echo '</pre>';
-    die;
-}
+// function dd(...$arguments)
+// {
+//     echo "<style>
+//         pre.dump {
+//             background-color: #18171B;
+//             color: white;
+//             line-height: 1.2em;
+//             font: 12px Menlo, Monaco, Consolas, monospace;
+//             word-wrap: break-word;
+//             white-space: pre-wrap;
+//             position: relative;
+//             z-index: 99999;
+//             word-break: break-all;
+//         }
+//         pre.dump:after {
+//             content: '';
+//             visibility: hidden;
+//             display: block;
+//             height: 0;
+//             clear: both;
+//         }
+//     </style>";
+//     echo '<pre class="dump">';
+//     var_dump(...$arguments);
+//     echo '</pre>';
+//     die;
+// }
 
 /**
  * Gets the value of an environment variable.

--- a/core/utils/debug.php
+++ b/core/utils/debug.php
@@ -30,3 +30,19 @@ function dd(...$arguments)
     echo '</pre>';
     die;
 }
+
+/**
+ * Gets the value of an environment variable.
+ * @param string $key
+ * @param mixed $default
+ * 
+ * @return mixed  
+ */
+function env($key, $default = null)
+{
+    if (isset($_ENV[$key])) {
+        return $_ENV[$key];
+    }
+
+    return $default;
+}

--- a/core/utils/helpers.php
+++ b/core/utils/helpers.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once 'debug.php';
+require_once 'view.php';


### PR DESCRIPTION
Similar to laravel it doesn't force env and serves config as the base
We will leave it without require until we provide a config method and I have it

* Created env function so we can control env more
* The env function allows you to choose a value if the key env does not exist, in short a default value
* Use the function in DB.php
* add Symfony dump
* autoload helpers.php
* format add phpunit test
* disable dd function on debug